### PR TITLE
Adds asciidoctor-rouge gem

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -11,6 +11,7 @@ RUN apk add --update --no-cache gcc g++ make bash curl unzip tar openjdk8-jre ru
     gem install --no-ri --no-rdoc asciidoctor-pdf --pre && \
     gem install --no-ri --no-rdoc asciidoctor-epub3 --pre && \
     gem install --no-ri --no-rdoc asciidoctor-confluence && \
+    gem install --no-ri --no-rdoc asciidoctor-rouge && \
     gem install --no-ri --no-rdoc coderay pygments.rb thread_safe epubcheck kindlegen && \
     gem install --no-ri --no-rdoc slim && \
     gem install --no-ri --no-rdoc haml tilt && \


### PR DESCRIPTION
asciidoctor-pdf comes bundled with the rouge gem allowing it to use `rouge` as its `source-highlighter`. In order to use rogue as the `source-highlighter` for asciidoctor we need to use the [asciidoctor-rouge](https://github.com/jirutka/asciidoctor-rouge) extension.  
  
This change allows the use of `rouge` as the `source-highlighter` across more document types than just PDF.